### PR TITLE
Add even more attributes

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -33,10 +33,6 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
 
-    - name: Restore NuGet packages
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
-
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).

--- a/resources/index.html
+++ b/resources/index.html
@@ -1018,7 +1018,7 @@
             attributes.append(createAttributeButton("Halloween Flames", "halloween_green_flames", 1008, 1))
             attributes.append(createAttributeButton("Voices from Below", "halloween_voice_modulation", 1006, 1))
             attributes.append(createAttributeButton("Jingle all the way", "add_jingle_to_footsteps", 364, 1))
-            attributes.append(createAttributeButton("Voices from Below", "set_custom_buildmenu", 295, 1))
+            attributes.append(createAttributeButton("Pip-Boy Build Menu", "set_custom_buildmenu", 295, 1))
 
             // Not setTimeout idiot
             setInterval(updateWeaponIndex, 1000);

--- a/resources/index.html
+++ b/resources/index.html
@@ -705,6 +705,7 @@
             370: { name: "set_attached_particle_static", label: "Unusual effect 2", type: 3 },
             134: { name: "set_attached_particle", label: "Unusual effect 1", type: 3 },
             2053: { name: "is_festivized", label: "Festivized", type: 1 },
+            719: { name: "weapon_uses_stattrak_module", label: "Festivized", type: 1 },
             2027: { name: "is_australium_item", label: "Australium", type: 1 },
             2022: { name: "loot_rarity", label: "Loot rarity", type: 1 },
             542: { name: "item_style_override", label: "Item style override", type: 1 },
@@ -1010,15 +1011,16 @@
             attributes.append(createAttributeButton("Unusual effect 1", "set_attached_particle", 134, 3));
             attributes.append(createAttributeButton("Unusual effect 2", "set_attached_particle_static", 370, 3));
             attributes.append(createAttributeButton("Festivized", "is_festivized", 2053, 1));
+            attributes.append(createAttributeButton("Stat Clock", "weapon_uses_stattrak_module", 719, 1));
             attributes.append(createAttributeButton("Australium", "is_australium_item", 2027, 1));
             attributes.append(createAttributeButton("Item style override", "item_style_override", 542, 1));
             attributes.append(createAttributeButton("Killstreak sheen", "killstreak_idleeffect", 2014, 3));
-            attributes.append(createAttributeButton("Killstreak effect", "killstreak_effect", 2013, 3))
-            attributes.append(createAttributeButton("Pumpkin Bombs", "halloween_pumpkin_explosions", 1007, 1))
+            attributes.append(createAttributeButton("Killstreak effect", "killstreak_effect", 2013, 3));
+            attributes.append(createAttributeButton("Pumpkin Bombs", "halloween_pumpkin_explosions", 1007, 1));
             attributes.append(createAttributeButton("Halloween Flames", "halloween_green_flames", 1008, 1))
-            attributes.append(createAttributeButton("Voices from Below", "halloween_voice_modulation", 1006, 1))
-            attributes.append(createAttributeButton("Jingle all the way", "add_jingle_to_footsteps", 364, 1))
-            attributes.append(createAttributeButton("Pip-Boy Build Menu", "set_custom_buildmenu", 295, 1))
+            attributes.append(createAttributeButton("Voices from Below", "halloween_voice_modulation", 1006, 1));
+            attributes.append(createAttributeButton("Jingle all the way", "add_jingle_to_footsteps", 364, 1));
+            attributes.append(createAttributeButton("Pip-Boy Build Menu", "set_custom_buildmenu", 295, 1));
 
             // Not setTimeout idiot
             setInterval(updateWeaponIndex, 1000);

--- a/resources/index.html
+++ b/resources/index.html
@@ -700,6 +700,7 @@
             2014: { name: "killstreak_idleeffect", label: "Killstreak sheen", type: 3 },
             1007: { name: "halloween_pumpkin_explosions", label: "Pumpkin Bombs", type: 1},
             1008: { name: "halloween_green_flames", label: "Halloween Flames", type: 1},
+            1006: { name: "halloween_voice_modulation", label: "Voices from Below", type: 1}
         };
     </script>
 </head>
@@ -995,6 +996,7 @@
             attributes.append(createAttributeButton("Killstreak sheen", "killstreak_idleeffect", 2014, 3));
             attributes.append(createAttributeButton("Pumpkin Bombs", "halloween_pumpkin_explosions", 1007, 1))
             attributes.append(createAttributeButton("Halloween Flames", "halloween_green_flames", 1008, 1))
+            attributes.append(createAttributeButton("Voices from Below", "halloween_voice_modulation", 1006, 1))
 
             // Not setTimeout idiot
             setInterval(updateWeaponIndex, 1000);

--- a/resources/index.html
+++ b/resources/index.html
@@ -684,6 +684,17 @@
             7: "Hot rod"
         };
 
+        const effectOptions = {
+            0: "None",
+            1: "Cerebral Discharge",
+            2: "Fire Horns",
+            3: "Flames",
+            4: "Hypno-Beam",
+            5: "Incinerator",
+            6: "Singularity",
+            7: "Tornado"
+        }
+
         const attributeInfo = {
             834: { name: "paintkit_proto_def_index", label: "Paint kit skin", type: 3 },
             866: { name: "custom_paintkit_seed_lo", label: "Paint kit seed (Low bytes)", type: 0 },
@@ -698,9 +709,12 @@
             2022: { name: "loot_rarity", label: "Loot rarity", type: 1 },
             542: { name: "item_style_override", label: "Item style override", type: 1 },
             2014: { name: "killstreak_idleeffect", label: "Killstreak sheen", type: 3 },
+            2013: { name: "killstreak_effect", label: "Killstreak effect", type: 3 },
             1007: { name: "halloween_pumpkin_explosions", label: "Pumpkin Bombs", type: 1},
             1008: { name: "halloween_green_flames", label: "Halloween Flames", type: 1},
-            1006: { name: "halloween_voice_modulation", label: "Voices from Below", type: 1}
+            1006: { name: "halloween_voice_modulation", label: "Voices from Below", type: 1},
+            364: { name: "add_jingle_to_footsteps", label: "Jingle all the way", type: 1},
+            295: { name: "set_custom_buildmenu", label:"Pipboy build menu", type: 1}
         };
     </script>
 </head>
@@ -862,6 +876,11 @@
                                 $list.append(`<option value="${key}">${sheenOptions[key]}</option>`);
                             }
                         }
+                        if (name == "killstreak_effect") {
+                            for (let key in effectOptions){
+                                $list.append(`<option value="${key}">${effectOptions[key]}</option>`);
+                            }
+                        }
 
                         $list.change(function () {
                             updateAttribute(weaponIndex, name, $(this).val());
@@ -994,6 +1013,7 @@
             attributes.append(createAttributeButton("Australium", "is_australium_item", 2027, 1));
             attributes.append(createAttributeButton("Item style override", "item_style_override", 542, 1));
             attributes.append(createAttributeButton("Killstreak sheen", "killstreak_idleeffect", 2014, 3));
+            attributes.append(createAttributeButton("Killstreak effect", "killstreak_effect", 2013, 3))
             attributes.append(createAttributeButton("Pumpkin Bombs", "halloween_pumpkin_explosions", 1007, 1))
             attributes.append(createAttributeButton("Halloween Flames", "halloween_green_flames", 1008, 1))
             attributes.append(createAttributeButton("Voices from Below", "halloween_voice_modulation", 1006, 1))

--- a/resources/index.html
+++ b/resources/index.html
@@ -1017,6 +1017,8 @@
             attributes.append(createAttributeButton("Pumpkin Bombs", "halloween_pumpkin_explosions", 1007, 1))
             attributes.append(createAttributeButton("Halloween Flames", "halloween_green_flames", 1008, 1))
             attributes.append(createAttributeButton("Voices from Below", "halloween_voice_modulation", 1006, 1))
+            attributes.append(createAttributeButton("Jingle all the way", "add_jingle_to_footsteps", 364, 1))
+            attributes.append(createAttributeButton("Voices from Below", "set_custom_buildmenu", 295, 1))
 
             // Not setTimeout idiot
             setInterval(updateWeaponIndex, 1000);

--- a/resources/index.html
+++ b/resources/index.html
@@ -673,6 +673,13 @@
             704: "Energy Orb",
         };
 
+        const tierOptions = {
+            0: "None",
+            1: "Basic",
+            2: "Specialized",
+            3: "Professional"
+        }
+
         const sheenOptions = {
             0: "None",
             1: "Team shine",
@@ -705,10 +712,10 @@
             370: { name: "set_attached_particle_static", label: "Unusual effect 2", type: 3 },
             134: { name: "set_attached_particle", label: "Unusual effect 1", type: 3 },
             2053: { name: "is_festivized", label: "Festivized", type: 1 },
-            719: { name: "weapon_uses_stattrak_module", label: "Festivized", type: 1 },
             2027: { name: "is_australium_item", label: "Australium", type: 1 },
             2022: { name: "loot_rarity", label: "Loot rarity", type: 1 },
             542: { name: "item_style_override", label: "Item style override", type: 1 },
+            2025: { name: "killstreak_tier", label: "Killstreak tier", type: 3 },
             2014: { name: "killstreak_idleeffect", label: "Killstreak sheen", type: 3 },
             2013: { name: "killstreak_effect", label: "Killstreak effect", type: 3 },
             1007: { name: "halloween_pumpkin_explosions", label: "Pumpkin Bombs", type: 1},
@@ -872,6 +879,11 @@
                                 $list.append(`<option value="${key}">${unusualOptions[key]}</option>`);
                             }
                         }
+                        if (name == "killstreak_tier") {
+                            for (let key in tierOptions) {
+                                $list.append(`<option value="${key}">${tierOptions[key]}</option>`);
+                            }
+                        }
                         if (name == "killstreak_idleeffect") {
                             for (let key in sheenOptions) {
                                 $list.append(`<option value="${key}">${sheenOptions[key]}</option>`);
@@ -1011,8 +1023,8 @@
             attributes.append(createAttributeButton("Unusual effect 1", "set_attached_particle", 134, 3));
             attributes.append(createAttributeButton("Unusual effect 2", "set_attached_particle_static", 370, 3));
             attributes.append(createAttributeButton("Festivized", "is_festivized", 2053, 1));
-            attributes.append(createAttributeButton("Stat Clock", "weapon_uses_stattrak_module", 719, 1));
             attributes.append(createAttributeButton("Australium", "is_australium_item", 2027, 1));
+            attributes.append(createAttributeButton("Killstreak Tier", "killstreak_tier", 2025, 3)); // I assume that 1=basic, 2=specialized, and 3=professional, although it could be a bool
             attributes.append(createAttributeButton("Item style override", "item_style_override", 542, 1));
             attributes.append(createAttributeButton("Killstreak sheen", "killstreak_idleeffect", 2014, 3));
             attributes.append(createAttributeButton("Killstreak effect", "killstreak_effect", 2013, 3));

--- a/resources/index.html
+++ b/resources/index.html
@@ -1017,7 +1017,7 @@
             attributes.append(createAttributeButton("Killstreak sheen", "killstreak_idleeffect", 2014, 3));
             attributes.append(createAttributeButton("Killstreak effect", "killstreak_effect", 2013, 3));
             attributes.append(createAttributeButton("Pumpkin Bombs", "halloween_pumpkin_explosions", 1007, 1));
-            attributes.append(createAttributeButton("Halloween Flames", "halloween_green_flames", 1008, 1))
+            attributes.append(createAttributeButton("Halloween Flames", "halloween_green_flames", 1008, 1));
             attributes.append(createAttributeButton("Voices from Below", "halloween_voice_modulation", 1006, 1));
             attributes.append(createAttributeButton("Jingle all the way", "add_jingle_to_footsteps", 364, 1));
             attributes.append(createAttributeButton("Pip-Boy Build Menu", "set_custom_buildmenu", 295, 1));

--- a/src/app/SkinChanger/SkinChanger.h
+++ b/src/app/SkinChanger/SkinChanger.h
@@ -19,7 +19,6 @@ namespace attributes
 	constexpr uint16_t item_style_override = 542;
 	constexpr uint16_t killstreak_tier = 2025;
 	constexpr uint16_t killstreak_effect = 2013;
-	constexpr uint16_t killstreak_effect = 2013;
 	constexpr uint16_t killstreak_idleeffect = 2014;
 	constexpr uint16_t halloween_pumpkin_explosions = 1007;
 	constexpr uint16_t halloween_green_flames = 1008;

--- a/src/app/SkinChanger/SkinChanger.h
+++ b/src/app/SkinChanger/SkinChanger.h
@@ -21,6 +21,7 @@ namespace attributes
 	constexpr uint16_t killstreak_idleeffect = 2014;
 	constexpr uint16_t halloween_pumpkin_explosions = 1007;
 	constexpr uint16_t halloween_green_flames = 1008;
+	constexpr uint16_t halloween_voice_modulation = 1006;
 
 #define HashCase(str) case FNV1A::HashConst(#str): return str
 
@@ -46,6 +47,7 @@ namespace attributes
 			HashCase(killstreak_idleeffect);
 			HashCase(halloween_pumpkin_explosions);
 			HashCase(halloween_green_flames);
+			HashCase(halloween_voice_modulation);
 			default:
 				return 0;
 		}

--- a/src/app/SkinChanger/SkinChanger.h
+++ b/src/app/SkinChanger/SkinChanger.h
@@ -23,6 +23,8 @@ namespace attributes
 	constexpr uint16_t halloween_pumpkin_explosions = 1007;
 	constexpr uint16_t halloween_green_flames = 1008;
 	constexpr uint16_t halloween_voice_modulation = 1006;
+	constexpr uint16_t add_jingle_to_footsteps = 364;
+	constexpr uint16_t set_custom_buildmenu = 295;
 
 #define HashCase(str) case FNV1A::HashConst(#str): return str
 
@@ -50,6 +52,8 @@ namespace attributes
 			HashCase(halloween_pumpkin_explosions);
 			HashCase(halloween_green_flames);
 			HashCase(halloween_voice_modulation);
+			HashCase(add_jingle_to_footsteps);
+			HashCase(set_custom_buildmenu);
 			default:
 				return 0;
 		}

--- a/src/app/SkinChanger/SkinChanger.h
+++ b/src/app/SkinChanger/SkinChanger.h
@@ -14,6 +14,7 @@ namespace attributes
 	constexpr uint16_t set_attached_particle_static = 370;
 	constexpr uint16_t set_attached_particle = 134;
 	constexpr uint16_t is_festivized = 2053;
+	constexpr uint16_t weapon_uses_stattrak_module = 719;
 	constexpr uint16_t is_australium_item = 2027;
 	constexpr uint16_t loot_rarity = 2022;
 	constexpr uint16_t item_style_override = 542;
@@ -43,6 +44,7 @@ namespace attributes
 			HashCase(set_attached_particle_static);
 			HashCase(set_attached_particle);
 			HashCase(is_festivized);
+			HashCase(weapon_uses_stattrak_module);
 			HashCase(is_australium_item);
 			HashCase(loot_rarity);
 			HashCase(item_style_override);

--- a/src/app/SkinChanger/SkinChanger.h
+++ b/src/app/SkinChanger/SkinChanger.h
@@ -18,6 +18,7 @@ namespace attributes
 	constexpr uint16_t loot_rarity = 2022;
 	constexpr uint16_t item_style_override = 542;
 	constexpr uint16_t set_turn_to_gold = 150;
+	constexpr uint16_t killstreak_effect = 2013;
 	constexpr uint16_t killstreak_idleeffect = 2014;
 	constexpr uint16_t halloween_pumpkin_explosions = 1007;
 	constexpr uint16_t halloween_green_flames = 1008;
@@ -44,6 +45,7 @@ namespace attributes
 			HashCase(loot_rarity);
 			HashCase(item_style_override);
 			HashCase(set_turn_to_gold);
+			HashCase(killstreak_effect)
 			HashCase(killstreak_idleeffect);
 			HashCase(halloween_pumpkin_explosions);
 			HashCase(halloween_green_flames);

--- a/src/app/SkinChanger/SkinChanger.h
+++ b/src/app/SkinChanger/SkinChanger.h
@@ -14,11 +14,11 @@ namespace attributes
 	constexpr uint16_t set_attached_particle_static = 370;
 	constexpr uint16_t set_attached_particle = 134;
 	constexpr uint16_t is_festivized = 2053;
-	constexpr uint16_t weapon_uses_stattrak_module = 719;
 	constexpr uint16_t is_australium_item = 2027;
 	constexpr uint16_t loot_rarity = 2022;
 	constexpr uint16_t item_style_override = 542;
-	constexpr uint16_t set_turn_to_gold = 150;
+	constexpr uint16_t killstreak_tier = 2025;
+	constexpr uint16_t killstreak_effect = 2013;
 	constexpr uint16_t killstreak_effect = 2013;
 	constexpr uint16_t killstreak_idleeffect = 2014;
 	constexpr uint16_t halloween_pumpkin_explosions = 1007;
@@ -44,11 +44,11 @@ namespace attributes
 			HashCase(set_attached_particle_static);
 			HashCase(set_attached_particle);
 			HashCase(is_festivized);
-			HashCase(weapon_uses_stattrak_module);
 			HashCase(is_australium_item);
 			HashCase(loot_rarity);
 			HashCase(item_style_override);
 			HashCase(set_turn_to_gold);
+			HashCase(killstreak_tier);
 			HashCase(killstreak_effect);
 			HashCase(killstreak_idleeffect);
 			HashCase(halloween_pumpkin_explosions);

--- a/src/app/SkinChanger/SkinChanger.h
+++ b/src/app/SkinChanger/SkinChanger.h
@@ -45,7 +45,7 @@ namespace attributes
 			HashCase(loot_rarity);
 			HashCase(item_style_override);
 			HashCase(set_turn_to_gold);
-			HashCase(killstreak_effect)
+			HashCase(killstreak_effect);
 			HashCase(killstreak_idleeffect);
 			HashCase(halloween_pumpkin_explosions);
 			HashCase(halloween_green_flames);

--- a/src/app/SkinChanger/SkinChanger.h
+++ b/src/app/SkinChanger/SkinChanger.h
@@ -17,6 +17,7 @@ namespace attributes
 	constexpr uint16_t is_australium_item = 2027;
 	constexpr uint16_t loot_rarity = 2022;
 	constexpr uint16_t item_style_override = 542;
+	constexpr uint16_t set_turn_to_gold = 150;
 	constexpr uint16_t killstreak_tier = 2025;
 	constexpr uint16_t killstreak_effect = 2013;
 	constexpr uint16_t killstreak_idleeffect = 2014;


### PR DESCRIPTION
Half of these are useless, but I know people would use them. The killstreak effect thing apparently requires that the weapon already be killstreak, but that shouldn't be an issue.
Edit: The statclocks are untested, and I don't know if it actually reflects your strange count on non warpainted weapons (if it even works).